### PR TITLE
Allow use of soundcard stream even in PyDAQmx is not available.

### DIFF
--- a/pydvma/streams.py
+++ b/pydvma/streams.py
@@ -2,8 +2,15 @@
 
 import pyaudio
 import numpy as np
-import PyDAQmx as pdaq
-from PyDAQmx import Task
+
+try:
+    import PyDAQmx as pdaq
+    from PyDAQmx import Task
+except ImportError:
+    pdaq = None
+except NotImplementedError:
+    pdaq = None
+
 
 
 


### PR DESCRIPTION
On OS X, it gives a NotImplementedError if the Python library is installed, so
check for that too.