### PR TITLE
Fix cDAQ chassis detection for nidaqmx 2026 Q2

### DIFF
--- a/pydvma/_ni_backend.py
+++ b/pydvma/_ni_backend.py
@@ -50,8 +50,20 @@ def resolve_terminal_config(ni_mode):
     return getattr(TerminalConfiguration, enum_name)
 
 
+# Accept either name: nidaqmx uses `COMPACT_DAQ_CHASSIS` (observed on
+# nidaqmx 2026 Q2); some older / alternate builds exposed `C_DAQ_CHASSIS`.
+# Comparing by `.name` avoids a hard dependency on the exact enum layout.
+_CHASSIS_CATEGORY_NAMES = frozenset({
+    'COMPACT_DAQ_CHASSIS',
+    'C_DAQ_CHASSIS',
+})
+
+
 def _is_chassis(dev):
-    return getattr(dev, 'product_category', None) == ProductCategory.C_DAQ_CHASSIS
+    pc = getattr(dev, 'product_category', None)
+    if pc is None:
+        return False
+    return getattr(pc, 'name', None) in _CHASSIS_CATEGORY_NAMES
 
 
 def _ai_count(dev):

--- a/tests/test_ni_backend.py
+++ b/tests/test_ni_backend.py
@@ -33,7 +33,9 @@ class _FakeEnumValue(object):
         return hash(self.name)
 
 
-FAKE_CHASSIS = _FakeEnumValue('C_DAQ_CHASSIS')
+# Real nidaqmx (observed on 2026 Q2) spells the chassis category
+# `COMPACT_DAQ_CHASSIS`; we also accept `C_DAQ_CHASSIS` for forward-compat.
+FAKE_CHASSIS = _FakeEnumValue('COMPACT_DAQ_CHASSIS')
 FAKE_USB = _FakeEnumValue('USB_DAQ')
 
 
@@ -126,6 +128,15 @@ class TestEnumerateDevices:
         chassis = FakeDevice('cDAQ1', 'cDAQ-9185', chassis=True, modules=[mod])
         entries = _ni.enumerate_devices(system=FakeSystem([usb, chassis, mod]))
         assert [e['name'] for e in entries] == ['Dev1', 'cDAQ1']
+
+    def test_accepts_legacy_chassis_enum_name(self, patch_ni):
+        # Older / alternate nidaqmx builds may expose `C_DAQ_CHASSIS`
+        # instead of `COMPACT_DAQ_CHASSIS`. Both must be treated as chassis.
+        mod = FakeDevice('cDAQ1Mod1', 'NI 9215', ai=4)
+        chassis = FakeDevice('cDAQ1', 'cDAQ-9185', chassis=True, modules=[mod])
+        chassis.product_category = _FakeEnumValue('C_DAQ_CHASSIS')
+        entries = _ni.enumerate_devices(system=FakeSystem([chassis, mod]))
+        assert len(entries) == 1 and entries[0]['is_chassis'] is True
 
     def test_returns_empty_when_nidaqmx_missing(self, monkeypatch):
         monkeypatch.setattr(_ni, 'nidaqmx', None)


### PR DESCRIPTION
The `ProductCategory` enum on the installed nidaqmx spells the chassis category `COMPACT_DAQ_CHASSIS`, not `C_DAQ_CHASSIS` as I had assumed — so `list_available_devices()` raised `AttributeError` on the nidaqmx enumeration path.

Match by `.name` and accept either spelling so this stays robust to any future rename. Added a regression test for the legacy name.